### PR TITLE
Added global iteration step and time stamp to the evaluation scores in cache/evaluation_scores.csv.

### DIFF
--- a/RUN_mdgru.py
+++ b/RUN_mdgru.py
@@ -19,6 +19,7 @@ LEARNINGRATE_DEFAULT = 1.0
 RANDOM_SEED_DEFAULT = 123456789
 UNCERTAINTYTIMES_DEFAULT = 1
 TEST_EACH_DEFAULT = 2500
+SAVE_EACH_DEFAULT = 2500
 GPUBOUNDFRACTION_DEFAULT = 1
 
 fullparameters = " ".join(sys.argv)
@@ -114,7 +115,8 @@ execution_parameters.add_argument('--learningrate', type=float, default=LEARNING
 execution_parameters.add_argument('--optionname', help='override optionname (used eg for saving results)')
 
 execution_parameters.add_argument('--testfirst', action="store_true", help="validate first")
-execution_parameters.add_argument('--testeach', default=TEST_EACH_DEFAULT, type=int, help='validate each # iterations')
+execution_parameters.add_argument('--test_each', default=TEST_EACH_DEFAULT, type=int, help='validate each # iterations')
+execution_parameters.add_argument('--save_each', default=SAVE_EACH_DEFAULT, type=int, help='save to ckpt each # iterations')
 execution_parameters.add_argument('--gpuboundfraction', default=GPUBOUNDFRACTION_DEFAULT, type=float,
                                   help='manage how much of the memory of the gpu can be used')
 execution_parameters.add_argument('--cpu', action="store_true", help='Only run on cpu')
@@ -183,7 +185,6 @@ args_runner = {
     "epochs": 0 if args.iterations else args.epochs,
     "test_size": 1,
     "test_iters": 1,
-    "save_each": 2500,
     "show_testing_results": True,
     "perform_n_times_full_validation": 1,
     "perform_n_times_full_validation_dropout": 1,
@@ -267,8 +268,10 @@ if args.ckpt is not None:
     args_runner['checkpointfile'] = args.ckpt
 if args.testbatchsize is not None:
     args_runner['test_size'] = args.testbatchsize
-if args.testeach is not None:
-    args_runner['test_each'] = args.testeach
+if args.test_each is not None:
+    args_runner['test_each'] = args.test_each
+if args.save_each is not None:
+    args_runner['save_each'] = args.save_each
 if args.gpuboundfraction is not None:
     args_runner['gpubound'] = args.gpuboundfraction
 if args.testfirst:

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -10,6 +10,7 @@ import shutil
 import signal
 import sys
 import time as time
+import datetime
 import csv
 from threading import Thread
 
@@ -164,17 +165,19 @@ class Runner(object):
 
         try:
             if self.results_to_csv:
-                with open(os.path.join(self.cachefolder, 'evaluation_scores.csv'),'a') as csvfile:
+                with open(os.path.join(self.cachefolder, 'evaluation_scores.csv'), 'a') as csvfile:
+
+                    globalstep = self.ev.sess.run(self.ev.model.global_step)
+                    currenttime = datetime.datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S')
+
                     validationWriter = csv.writer(csvfile)
-
-                    validationWriter.writerow(['score', 'label'] + [errors[i][0] for i in range(0, len(errors))])
-
+                    validationWriter.writerow(['score', 'label'] + [errors[i][0] for i in range(0, len(errors))] + ['iteration','time-stamp'])
                     for key in errors[0][1].keys():
                         try:
                             for label in range(0, len(error[0][1][key])):
-                                validationWriter.writerow([key] + ['label' + str(label)] + [str(errors[i][1][key][label]) for i in range(0, len(errors))])
+                                validationWriter.writerow([key] + ['label' + str(label)] + [str(errors[i][1][key][label]) for i in range(0, len(errors))] + [str(globalstep), currenttime])
                         except:
-                            validationWriter.writerow([key] + ['all_labels'] + [str(errors[i][1][key]) for i in range(0, len(errors))])
+                            validationWriter.writerow([key] + ['all_labels'] + [str(errors[i][1][key]) for i in range(0, len(errors))] + [str(globalstep), currenttime])
         except:
             logging.getLogger('runner').warning('could not write error to evaluation_scores.csv')
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -156,50 +156,14 @@ class Runner(object):
 
         errors = list(itertools.chain.from_iterable(errors))
 
-        avgerrors = {}
-        minerrors = {}
-        medianerrors = {}
-        maxerrors = {}
-        for k in errors[0][1].keys():
-            val = [errors[i][1][k] for i in range(len(errors)) if k in errors[i][1].keys()]
-            avgerrors[k] = np.mean(val, 0)
-            minerrors[k] = np.nanmin(val, 0)
-            medianerrors[k] = np.median(val, 0)
-            maxerrors[k] = np.nanmax(val, 0)
-        if self.ev.use_tensorboard:
-            for k, v in avgerrors.items():
-                if np.isscalar(v):
-                    v = [v]
-                for c, vv in enumerate(v):
-                    try:
-                        summary = tf.Summary()
-                        summary.value.add(tag='validation-mean-{}-{}'.format(k, c), simple_value=vv)
-                        self.ev.train_writer.add_summary(summary)
-                    except Exception as e:
-                        logging.getLogger('runner').warning('could not save {} as scalar value'.format(vv))
+        minerrors, avgerrors, medianerrors, maxerrors = self.calc_min_mean_median_max_errors(errors)
 
         logging.getLogger('runner').info("min    errors {}".format(minerrors))
         logging.getLogger('runner').info("mean   errors {}".format(avgerrors))
         logging.getLogger('runner').info("median errors {}".format(medianerrors))
         logging.getLogger('runner').info("max    errors {}".format(maxerrors))
 
-        try:
-            if self.results_to_csv:
-                with open(os.path.join(self.cachefolder, 'validation_scores.csv'), 'a') as csvfile:
-
-                    globalstep = self.ev.sess.run(self.ev.model.global_step)
-                    currenttime = datetime.datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S')
-
-                    validationWriter = csv.writer(csvfile)
-                    validationWriter.writerow(['score', 'label'] + [errors[i][0] for i in range(0, len(errors))] + ['iteration', 'time-stamp','score','label','min','mean','median','max'])
-                    for key in errors[0][1].keys():
-                        try:
-                            for label in range(0, len(error[0][1][key])):
-                                validationWriter.writerow([key] + ['label' + str(label)] + [str(errors[i][1][key][label]) for i in range(0, len(errors))] + [str(globalstep), currenttime, key] + ['label' + str(label)] + [str(minerrors[key][label]), str(avgerrors[key][label]), str(medianerrors[key][label]), str(maxerrors[key][label])] )
-                        except:
-                            validationWriter.writerow([key] + ['all_labels'] + [str(errors[i][1][key]) for i in range(0, len(errors))] + [str(globalstep), currenttime, key, 'all_labels'] + [str(minerrors[key]), str(avgerrors[key]), str(medianerrors[key]), str(maxerrors[key])])
-        except:
-            logging.getLogger('runner').warning('could not write error to validation_scores.csv')
+        self.write_error_to_csv(errors, 'validation_scores.csv', minerrors, avgerrors, medianerrors, maxerrors)
 
         return avgerrors
 
@@ -280,39 +244,64 @@ class Runner(object):
         self.checkpointfile = abspath+'-{}'.format(globalstep)
         logging.getLogger('runner').info('Saved checkpoint {}'.format(filename+'-{}'.format(globalstep)))
 
-    def test(self):
-        self.ev.tedc.p = np.int32(self.ev.tedc.p)
-        error = self.ev.test_all_available(batch_size=1, testing=True)
-
-        avgerrors = {}
-        minerrors = {}
-        medianerrors = {}
-        maxerrors = {}
-        for k in error[0][1].keys():
-            val = [error[i][1][k] for i in range(len(error)) if k in error[i][1].keys()]
-            avgerrors[k] = np.mean(val, 0)
-            minerrors[k] = np.nanmin(val, 0)
-            medianerrors[k] = np.median(val, 0)
-            maxerrors[k] = np.nanmax(val, 0)
+    def write_error_to_csv(self, errors, filename, minerrors, avgerrors, medianerrors, maxerrors):
 
         try:
             if self.results_to_csv:
-                with open(os.path.join(self.cachefolder, 'testing_scores.csv'), 'a') as csvfile:
+                with open(os.path.join(self.cachefolder, filename), 'a') as csvfile:
 
                     globalstep = self.ev.sess.run(self.ev.model.global_step)
                     currenttime = datetime.datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S')
                     ckptfile = self.checkpointfile # if self.checkpointfile is a list -> adapt ckptfile
 
-                    testWriter = csv.writer(csvfile)
-                    testWriter.writerow(['score', 'label'] + [error[i][0] for i in range(0, len(error))] + ['checkpoint', 'iteration', 'time-stamp','score','label','min','mean','median','max'])
-                    for key in error[0][1].keys():
+                    evaluationWriter = csv.writer(csvfile)
+                    evaluationWriter.writerow(['score', 'label'] + [errors[i][0] for i in range(0, len(errors))] + ['checkpoint', 'iteration', 'time-stamp','score','label','min','mean','median','max'])
+                    for key in errors[0][1].keys():
                         try:
-                            for label in range(0, len(error[0][1][key])):
-                                testWriter.writerow([key] + ['label' + str(label)] + [str(error[i][1][key][label]) for i in range(0, len(error))] + [ckptfile, str(globalstep), currenttime, key] + ['label' + str(label)] + [str(minerrors[key][label]), str(avgerrors[key][label]), str(medianerrors[key][label]), str(maxerrors[key][label])])
+                            for label in range(0, len(errors[0][1][key])):
+                                evaluationWriter.writerow([key] + ['label' + str(label)] + [str(errors[i][1][key][label]) for i in range(0, len(errors))] + [ckptfile, str(globalstep), currenttime, key] + ['label' + str(label)] + [str(minerrors[key][label]), str(avgerrors[key][label]), str(medianerrors[key][label]), str(maxerrors[key][label])])
                         except:
-                            testWriter.writerow([key] + ['all_labels'] + [str(error[i][1][key]) for i in range(0, len(error))] + [ckptfile, str(globalstep), currenttime, key, 'all_labels'] + [str(minerrors[key]), str(avgerrors[key]), str(medianerrors[key]), str(maxerrors[key])])
+                            evaluationWriter.writerow([key] + ['all_labels'] + [str(errors[i][1][key]) for i in range(0, len(errors))] + [ckptfile, str(globalstep), currenttime, key, 'all_labels'] + [str(minerrors[key]), str(avgerrors[key]), str(medianerrors[key]), str(maxerrors[key])])
         except:
-            logging.getLogger('runner').warning('could not write error to testing_scores.csv')
+            logging.getLogger('runner').warning('could not write error to ' + filename)
+
+
+    def calc_min_mean_median_max_errors(self, errors):
+        avgerrors = {}
+        minerrors = {}
+        medianerrors = {}
+        maxerrors = {}
+        for k in errors[0][1].keys():
+            val = [errors[i][1][k] for i in range(len(errors)) if k in errors[i][1].keys()]
+            avgerrors[k] = np.mean(val, 0)
+            minerrors[k] = np.nanmin(val, 0)
+            medianerrors[k] = np.median(val, 0)
+            maxerrors[k] = np.nanmax(val, 0)
+
+        if self.ev.use_tensorboard:
+            for k, v in avgerrors.items():
+                if np.isscalar(v):
+                    v = [v]
+                for c, vv in enumerate(v):
+                    try:
+                        summary = tf.Summary()
+                        summary.value.add(tag='validation-mean-{}-{}'.format(k, c), simple_value=vv)
+                        self.ev.train_writer.add_summary(summary)
+                    except Exception as e:
+                        logging.getLogger('runner').warning('could not save {} as scalar value'.format(vv))
+
+        return minerrors, avgerrors, medianerrors, maxerrors
+
+
+    def test(self):
+        self.ev.tedc.p = np.int32(self.ev.tedc.p)
+        errors = self.ev.test_all_available(batch_size=1, testing=True)
+
+        minerrors, avgerrors, medianerrors, maxerrors = self.calc_min_mean_median_max_errors(errors)
+
+        self.write_error_to_csv(errors, 'testing_scores.csv', minerrors, avgerrors, medianerrors, maxerrors)
+
+
 
     def run(self, **kw):
         # save this file as txt to cachefolder:

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -101,20 +101,6 @@ class Runner(object):
         self.notifyme = argget(kw, 'notifyme', None)
         self.results_to_csv = argget(kw, 'results_to_csv', False)
 
-        if self.results_to_csv:
-            if 'train' in self.episodes:
-                try:
-                    open(os.path.join(self.cachefolder, 'validation_scores.csv'), 'w') # mode w: any existing files with the same name in this cache folder will be erased
-                    logging.getLogger('runner').info('validation_scores.csv created.')
-                except:
-                    logging.getLogger('runner').warning('could not create validation_scores.csv.')
-            if 'test' in self.episodes:
-                try:
-                    open(os.path.join(self.cachefolder, 'testing_scores.csv'), 'w') # mode w: any existing files with the same name in this cache folder will be erased
-                    logging.getLogger('runner').info('testing_scores.csv created.')
-                except:
-                    logging.getLogger('runner').warning('could not create testing_scores.csv.')
-
         self.train_losses = []
         self.test_losses = []
         self.val_losses = []


### PR DESCRIPTION
2nd commit: I'm not sure, it is a good idea to change --testeach to --test_each but it matches to the variables in the code. (And yes, I'm sorry, changing -testeach to --test_each should have been in a seperate commit.)
3rd commit: evaluation_scores.csv --> validation_scores.csv and testing_scores.csv. All tests at all checkpoints shall be saved in the same testing_scores.csv. Depending on the implementation, ckptfile=self.checkpointfile has to be adapted to a **list** self.checkpointfile.