### PR TITLE
multiple checkpoints can now be provided at the same time. Added exam…

### DIFF
--- a/RUN_mdgru.py
+++ b/RUN_mdgru.py
@@ -108,11 +108,17 @@ execution_parameters.add_argument('--onlytest', action="store_true",
 execution_parameters.add_argument('--onlytrain', action="store_true",
                                                  help="only perform training phase, "
                                                       + "inferred, when no testing location is present")
-execution_parameters.add_argument('--ckpt', default=None,
-                                  help='provide checkpointfile for this template. If no modelname is provided, we will infer one from this file')
+execution_parameters.add_argument('--ckpt', default=None, nargs="+",
+                                  help='provide checkpointfile for this template. If no modelname is provided, '
+                                       'we will infer one from this file. Multiple files are only allowed if '
+                                       'only_test is set. If the same number of optionnames are provided, they will '
+                                       'be used to name the different results. If only one optionname is provided, they '
+                                       'will be numbered in order and the checkpoint filename will be included in the '
+                                       'result file.')
 execution_parameters.add_argument('--learningrate', type=float, default=LEARNINGRATE_DEFAULT,
                                   help='learningrate (for adadelta)')
-execution_parameters.add_argument('--optionname', help='override optionname (used eg for saving results)')
+execution_parameters.add_argument('--optionname', nargs="+", help='override optionname (used eg for saving results). '
+                                                                  'Can be either 1, or n in the case of n ckpts ')
 
 execution_parameters.add_argument('--testfirst', action="store_true", help="validate first")
 execution_parameters.add_argument('--test_each', default=TEST_EACH_DEFAULT, type=int, help='validate each # iterations')
@@ -220,10 +226,10 @@ if args.modelname is not None:
 elif args.ckpt is not None:
     from tensorflow.python import pywrap_tensorflow
     try:
-        r = pywrap_tensorflow.NewCheckpointReader(args.ckpt)
+        r = pywrap_tensorflow.NewCheckpointReader(args.ckpt[0])
         modelname = r.get_variable_to_shape_map().popitem()[0].split('/')[0]
     except:
-        logging.getLogger('runfile').warning('could not load modelname from ckpt-file {}'.format(args.ckpt))
+        logging.getLogger('runfile').warning('could not load modelname from ckpt-file {}'.format(args.ckpt[0]))
 if modelname is None:
     modelname = "f{}m{}d{}-{}w{}p{}bn{}res{}lr{}r{}ns{}-de{}-{}se{}_all".format(int(1 - args.nofsg),
                                                                             "".join(m),
@@ -265,7 +271,7 @@ elif args.onlytrain or (args.locationtesting is None):
 if args.iterations is not None:
     args_runner['its_per_epoch'] = args.iterations
 if args.ckpt is not None:
-    args_runner['checkpointfile'] = args.ckpt
+    args_runner['checkpointfiles'] = args.ckpt
 if args.testbatchsize is not None:
     args_runner['test_size'] = args.testbatchsize
 if args.test_each is not None:
@@ -278,7 +284,7 @@ if args.testfirst:
     args_runner['test_first'] = args.testfirst
 if args.cpu is not None:
     args_runner['only_cpu'] = args.cpu
-
+args_runner['estimatefilenames'] = optionname
 # data arguments
 
 args_data = {
@@ -407,5 +413,10 @@ else:
 
 ev = LargeVolumeClassificationEvaluation(mclassification, datadict,
                                          **args_eval)
-ev.estimatefilename = optionname
-Runner(ev, experiments_postfix="_" + optionname, **args_runner).run()
+if isinstance(optionname, list):
+    pf = "-".join(optionname)
+    if len(pf) > 40:
+        pf = pf[:39] + "..."
+else:
+    pf = optionname
+Runner(ev, experiments_postfix="_" + pf, **args_runner).run()

--- a/RUN_mdgru.py
+++ b/RUN_mdgru.py
@@ -138,6 +138,8 @@ execution_parameters.add_argument('--notifyme', default=None, nargs='?', type=st
                                        + ' follows: {"chat_id": CHATID, "token": TOKEN}, where CHATID and TOKEN '
                                        + 'have to be created with Telegrams BotFather. The chatid from config can be '
                                        + 'overriden using a parameter together with this option.')
+execution_parameters.add_argument('--only_save_labels', action='store_true', help='Writes only labelmaps to disk, ignoring'
+                                                'probability maps and hence saving a lot of disk space.')
 execution_parameters.add_argument('--results_to_csv', action="store_true", help='Writes validation scores to validation_scores.csv')
 
 args = parser.parse_args()
@@ -384,6 +386,7 @@ args_eval = {"batch_size": args.batchsize,
              'swap_memory': args.swap_memory,
              'use_dropconnect_on_state': args.use_dropconnect_on_state,
              'legacy_cgru_addition': args.legacy_cgru_addition,
+             'only_save_labels': args.only_save_labels
              }
 
 if not args.dont_use_tensorboard and args.image_summaries_each is not None:

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -186,6 +186,7 @@ class SupervisedEvaluation(Evaluation):
         self.setupCollections(collectioninst)
         self.currit = 0
         self.namespace = argget(kw, "namespace", "default")
+        self.only_save_labels = argget(kw, "only_save_labels", False)
         with tf.variable_scope(self.namespace):
             self.training = tf.placeholder(dtype=tf.bool)
             self.dropout = tf.placeholder(dtype=tf.float32)
@@ -430,7 +431,8 @@ class LargeVolumeEvaluation(Evaluation):
             if return_results:
                 full_vols.append([name, file, res])
             else:
-                dc.save(res, os.path.join(file, self.estimatefilename + "-probdist"), tporigin=file)
+                if not self.only_save_labels:
+                    dc.save(res, os.path.join(file, self.estimatefilename + "-probdist"), tporigin=file)
                 dc.save(np.uint8(np.argmax(res, -1)), os.path.join(file, self.estimatefilename + "-labels"), tporigin=file)
             logging.getLogger('eval').info('evaluation took {} seconds'.format(time.time() - lasttime))
             lasttime = time.time()

--- a/examples/dummy3d/eval_last_ckpt.sh
+++ b/examples/dummy3d/eval_last_ckpt.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+# Automatically find last checkpoint file (first line), and evaluate that model on the test data (second line)
+
+ckpt=$(ls `pwd`/nifti/experiments/mdgru_discardme/*/cache/*.ckpt-*.index -dArt | grep -v -e "latest" | tail -n 1 | sed 's/.index//g')
+
+python3 ../../RUN_mdgru.py --datapath `pwd`/nifti --onlytest --locationtesting test --optionname discardme -p 0 0 0 -w 40 100 100 -f flair.nii.gz t2.nii.gz pd.nii.gz mprage.nii.gz -m mask1.nii.gz --nclasses 2 --num_threads 4 --ckpt $ckpt 
+

--- a/examples/dummy3d/eval_last_two_ckpts.sh
+++ b/examples/dummy3d/eval_last_two_ckpts.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Automatically select last two checkpoints (first line) and evaluate them using automatic naming using one optionname (second line)
+
+ckpts=$(ls `pwd`/nifti/experiments/mdgru_discardme/*/cache/*.ckpt-*.index -dArt | grep -v -e "latest" | tail -n 2 | sed 's/.index//g')
+
+python3 ../../RUN_mdgru.py --datapath `pwd`/nifti --onlytest --locationtesting test --optionname discardme -p 0 0 0 -w 40 100 100 -f flair.nii.gz t2.nii.gz pd.nii.gz mprage.nii.gz -m mask1.nii.gz --nclasses 2 --num_threads 4 --ckpt $ckpts 
+

--- a/examples/dummy3d/eval_last_two_ckpts_with_names.sh
+++ b/examples/dummy3d/eval_last_two_ckpts_with_names.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Automatically load last two checkpoint files (first name) and use provided optionnames for each of them during evaluation (second line)
+
+ckpts=$(ls `pwd`/nifti/experiments/mdgru_discardme/*/cache/*.ckpt-*.index -dArt | grep -v -e "latest" | tail -n 2 | sed 's/.index//g')
+
+python3 ../../RUN_mdgru.py --datapath `pwd`/nifti --onlytest --locationtesting test --optionname discardfirst discardsecond -p 0 0 0 -w 40 100 100 -f flair.nii.gz t2.nii.gz pd.nii.gz mprage.nii.gz -m mask1.nii.gz --nclasses 2 --num_threads 4 --ckpt $ckpts 
+

--- a/examples/dummy3d/train.sh
+++ b/examples/dummy3d/train.sh
@@ -1,2 +1,5 @@
-python3 ../../RUN_mdgru.py --datapath `pwd`/nifti --locationtraining train --locationvalidation val --locationtesting test --optionname discardme --modelname discardme -w 20 50 50 --paddingtesting 0 0 0 --windowsizetesting 40 100 100 -p 10 10 10 -f flair.nii.gz t2.nii.gz pd.nii.gz mprage.nii.gz -m mask1.nii.gz --iterations 100 --test_each 50 --nclasses 2 --num_threads 4
+#!/bin/bash
+# Automatically train and test on the previously created test data. This does not use any form of data augmentation.
+
+python3 ../../RUN_mdgru.py --datapath `pwd`/nifti --locationtraining train --locationvalidation val --locationtesting test --optionname discardme --modelname discardme -w 20 50 50 --paddingtesting 0 0 0 --windowsizetesting 40 100 100 -p 10 10 10 -f flair.nii.gz t2.nii.gz pd.nii.gz mprage.nii.gz -m mask1.nii.gz --iterations 100 --test_each 50 --save_each 50 --nclasses 2 --num_threads 4
 


### PR DESCRIPTION
…ples for 3d to demonstrate how to use this feature

This should address all but the last point in #10. I dont think completely ignoring the output is a good idea, as sometimes a new measure should be evaluated and then there is no way to compute this measure without running everything again. As labelmaps can be compressed substantially, I would suggest a new option, which allows to only save labelmaps and no probability maps. This should result in substantially less space requirements for the results, and new measures could be computed on the labelmaps at least. 