### PR TITLE
Closes issue #37

### DIFF
--- a/mdgru/data/grid_collection.py
+++ b/mdgru/data/grid_collection.py
@@ -17,7 +17,8 @@ from mvloader.volume import Volume
 import nrrd
 import numpy as np
 import skimage.io as skio
-from scipy.misc import imsave, imread
+# from scipy.misc import imsave, imread #--- imsave deprecated, use imageio.imwrite and imageio.imread instead
+from imageio import imwrite, imread
 from scipy.ndimage.filters import gaussian_filter
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.ndimage.measurements import label
@@ -281,13 +282,13 @@ class GridDataCollection(DataCollection):
             except Exception as e:
                 ending = os.path.splitext(self.featurefiles[0])[-1]
         if ending in ['.mhd']:
-            skio.imsave(filename + ending, data, plugin='simpleitk')
+            skio.imwrite(filename + ending, data, plugin='simpleitk')
         elif ending in ['.raw']:
             data.astype('int16').tofile(filename + ending)
         elif ending in ['.png', '.jpeg', '.png', '.pgm', '.pnm', '.gif', '.tif', '.tiff']:
             if np.max(data) <= 1.0 and np.min(data) >= 0:
                 np.int8(np.clip(data * 256, 0, 255))
-                imsave(filename + ending, data.squeeze())
+                imwrite(filename + ending, data.squeeze())
         else:
             # ending in ['.nii', '.hdr', '.nii.gz', '.gz', '.dcm'] or len(data.squeeze().shape) > 2:
             if self.correct_orientation and tporigin is not None:

--- a/mdgru/data/grid_collection.py
+++ b/mdgru/data/grid_collection.py
@@ -282,7 +282,7 @@ class GridDataCollection(DataCollection):
             except Exception as e:
                 ending = os.path.splitext(self.featurefiles[0])[-1]
         if ending in ['.mhd']:
-            skio.imwrite(filename + ending, data, plugin='simpleitk')
+            skio.imsave(filename + ending, data, plugin='simpleitk')
         elif ending in ['.raw']:
             data.astype('int16').tofile(filename + ending)
         elif ending in ['.png', '.jpeg', '.png', '.pgm', '.pnm', '.gif', '.tif', '.tiff']:

--- a/mdgru/model/mdgru_classification.py
+++ b/mdgru/model/mdgru_classification.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright (C) 2017 Simon Andermatt"
 
 import numpy as np
 import tensorflow as tf
+import logging
 
 from mdgru.helper import argget, collect_parameters, define_arguments, compile_arguments
 from mdgru.model import save_summary_for_nd_images
@@ -111,6 +112,12 @@ class MDGRUClassificationWithDiceLoss(MDGRUClassification):
         self.dice_loss_weight = argget(kw, "dice_loss_weight", [])
         self.dice_autoweighted = argget(kw, "dice_autoweighted", False)
 
+        self.logger = logging.getLogger('runner.model')
+        self.logger.debug('initialization MDGRUClassificationWithDiceLoss:')
+        self.logger.debug(f' self.dice_loss_label: {self.dice_loss_label}')
+        self.logger.debug(f' self.dice_loss_weight: {self.dice_loss_weight}')
+        self.logger.debug(f' self.dice_autoweighted: {self.dice_autoweighted}')
+        
         if len(self.dice_loss_label) != len(self.dice_loss_weight) and not self.dice_autoweighted:
             raise Exception("dice_loss_label and dice_loss_weight need to be of the same length")
 
@@ -155,6 +162,12 @@ class MDGRUClassificationWithGeneralizedDiceLoss(MDGRUClassification):
         self.dice_loss_weight = argget(kw, "dice_loss_weight", [])
         self.dice_autoweighted = argget(kw, "dice_autoweighted", False)
 
+        self.logger = logging.getLogger('runner.model')
+        self.logger.debug('initialization MDGRUClassificationWithGeneralizedDiceLoss:')
+        self.logger.debug(f' self.dice_loss_label: {self.dice_loss_label}')
+        self.logger.debug(f' self.dice_loss_weight: {self.dice_loss_weight}')
+        self.logger.debug(f' self.dice_autoweighted: {self.dice_autoweighted}')
+        
         if len(self.dice_loss_label) != len(self.dice_loss_weight) and not self.dice_autoweighted:
             raise Exception("dice_loss_label and dice_loss_weight need to be of the same length")
 

--- a/mdgru/runner.py
+++ b/mdgru/runner.py
@@ -120,27 +120,27 @@ class Runner(object):
         self.experiments = os.path.join(experiments_nots, str(int(time.time())))
         self.cachefolder = os.path.join(self.experiments, 'cache')
         os.makedirs(self.cachefolder)
-        # logging:
+        
+        # Add Logging.FileHandler (StreamHandler was added already in RUN_mdgru.py)
         loggers = [logging.getLogger(n) for n in ['model', 'eval', 'runner', 'helper', 'data']]
         formatter = logging.Formatter('%(asctime)s %(name)s\t%(levelname)s:\t%(message)s')
         logfile = argget(kw, 'logfile', os.path.join(self.cachefolder, 'log.txt'))
         fh = logging.FileHandler(logfile)
         fh.setLevel(argget(kw, 'logfileloglvl', logging.DEBUG))
         fh.setFormatter(formatter)
-
-        ch = logging.StreamHandler()
-        ch.setFormatter(formatter)
-        ch.setLevel(argget(kw, 'loglvl', logging.WARNING))
+        # ch = logging.StreamHandler()
+        # ch.setFormatter(formatter)
+        # ch.setLevel(argget(kw, 'loglvl', logging.DEBUG))        
         for logger in loggers:
-            logger.addHandler(ch)
             logger.setLevel(logging.DEBUG)
+            # logger.addHandler(ch)
             logger.addHandler(fh)
 
         for k in self.origargs:
-            logging.getLogger('runner').info('arg {}:{}'.format(k, self.origargs[k]))
+            logging.getLogger('runner').info('args runner {}:{}'.format(k, self.origargs[k]))
         self.ev = evaluationinstance
         for k in self.ev.origargs:
-            logging.getLogger('eval/data/model').info('arg {}:{}'.format(k, self.ev.origargs[k]))
+            logging.getLogger('runner').info('args eval/data/model {}:{}'.format(k, self.ev.origargs[k]))
         # for k in self.ev.trdc.origargs:
         #     logging.getLogger('data').info(' trdc arg {}:{}'.format(k, self.ev.trdc.origargs[k]))
         # for k in self.ev.tedc.origargs:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages('.') + ['.'],
     license="LGPL",
     python_requires='>=3.5',
-    install_requires=["nibabel==2.5.0", "numpy==1.15.1", "scipy==1.0.0", "pydicom==1.3.0", "matplotlib==3.0.3", "scikit-image==0.15.0", "simpleitk==1.2.2", "tensorflow-gpu==1.8", "torch==1.2.0", "torchvision==0.4.0", "visdom==0.1.8.9"],
+    install_requires=["nibabel==2.5.0", "numpy==1.15.1", "scipy==1.0.0", "pydicom==1.3.0", "matplotlib==3.0.3", "scikit-image==0.15.0", "simpleitk==1.2.2", "tensorflow-gpu==1.8", "torch==1.2.0", "torchvision==0.4.0", "visdom==0.1.8.9", "imageio==2.13.5"],
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',


### PR DESCRIPTION
#37 
- Retain dice-loss options being lost during compilation of arguments in `RUN_mdgru.py`
- Add debug log to model initialisation to double-check use of correct dice-loss options
- Fixed duplicate logging
- Add logging.Streamhandler already in `RUN_mdgru.py`, to allow catching early debug messages. Instead, FileHandler will still be added later in `runner.py`
- Use `imageio.imwrite` and i`mageio.imread` instead of the deprecated `scipy.misc.imsave` and `scipy.misc.imread`